### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-on: [push]
 name: CI
+on: [push, pull_request]
 jobs:
   build_and_test:
     name: Build and Test
@@ -8,7 +8,7 @@ jobs:
       matrix:
         node: ['13', '12']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Since recent changes have been made to Actions for the forked repository to prevent automatic CI execution. So, the `pull_request` should also be enabled.