### PR TITLE
Add windows support

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -56,7 +56,7 @@ export default class GenerateCommand extends Command {
     let templateName = args.templateName;
 
     const cwd = process.cwd();
-    const dir = path.resolve(cwd, templateDir as string);
+    const dir = path.resolve(cwd, templateDir).replace(/\\/g, '/');
     const reader = new Reader(dir);
     const documents = reader.readAll();
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -18,7 +18,7 @@ export default class ListCommand extends Command {
     } = this.parse(ListCommand);
 
     const cwd = process.cwd();
-    const reader = new Reader(path.resolve(cwd, templateDir as string));
+    const reader = new Reader(path.resolve(cwd, templateDir).replace(/\\/g, '/'));
     const documents = reader.readAll();
 
     for (const document of documents) {

--- a/src/template/reader.ts
+++ b/src/template/reader.ts
@@ -57,7 +57,7 @@ export class Reader {
   }
 
   private list() {
-    return globby.sync(`${path.join(this.dir, '*.md')}`, { onlyFiles: true }).map((file) => path.basename(file));
+    return globby.sync(path.posix.join(this.dir, '*.md'), { onlyFiles: true }).map((file) => path.basename(file));
   }
 
   private collect(tokens: marked.TokensList) {


### PR DESCRIPTION
## What does this do / why do we need it?

This PR fixes `list` and `generate` commands' behavior abount their file resolution on Windows.
Before this change, the `list` command cannot find any `.md` files and the `generate` command cannot find any templates.

## How this PR fixes the problem?

The above problem is caused by `globby`'s complicated behavior.
According to its [API documentation](https://github.com/sindresorhus/globby#api), glob patterns must be constructed using not backward-slashes but forward-slashes.

On Windows, `process.cwd()` and `path.join()` return path strings containing backward-slashes.
Thus, `globby.sync(...)` (at `src/template/reader.ts`) always returns empty array.
Consequently, the above problem occurs.

This PR fixes it in the following steps.

1. Add logic that the backward-slashes which appear in the path string are replaced with forward-slashes
2. Replace `path.join` with `path.posix.join` so as not to use backward-slashes as delimiters

## What should your reviewer look out for in this PR?

Please check if the file resolution works properly on other environments such as macOS and Linux.

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)
