### PR TITLE
Fix type declarations which prevent migration to typescript 3.8

### DIFF
--- a/src/template/reader.ts
+++ b/src/template/reader.ts
@@ -9,16 +9,19 @@ export type Resource = {
   content: string;
 };
 
-export type Attributes = {
-  extends: string; // TODO
+type SpecifiedAttributes = {
   name: string;
-  description: string;
   message: string;
-  root: string;
   output: string;
-  ignore: string[];
-  hooks: string[]; // TODO
+
+  extends?: string;
+  description?: string;
+  root?: string;
+  ignore?: string[];
+  hooks?: string[];
 };
+
+export type Attributes = Required<SpecifiedAttributes>;
 
 export type Document = {
   path: string;
@@ -36,7 +39,7 @@ export class Reader {
   private read(filename: string): Document {
     const template = path.resolve(this.dir, filename);
     const markdown = fs.readFileSync(template, { encoding: 'utf8' });
-    const { attributes, body } = fm(markdown);
+    const { attributes, body } = fm<SpecifiedAttributes>(markdown);
     const resources = this.collect(marked.lexer(body));
 
     return {


### PR DESCRIPTION
## What does this do / why do we need it?

Previously, when the `fm` function (exported from `front-matter` module) takes no type arguments, its return type has been inferred to `FrontMatterResult<any>`.
Thus, the following code (including spread operator with `any` value) has been compiled successfully.

https://github.com/cats-oss/scaffdog/blob/44be9293d6354a2ee1c5ee80ad3f1ba03f231840/src/template/reader.ts#L36-L57

If we migrate from TS 3.7 to 3.8, however, the inferred type of `fm(markdown)` is changed to `FrontMatterResult<unknown>`.
Under the influence of the breaking change, the compilation in [this workflow](https://github.com/cats-oss/scaffdog/runs/475927829?check_suite_focus=true) failed.

Therefore, I updated type declarations so that this project is compiled successfully also in TS 3.8 or later.

## How this PR fixes the problem?

1. Define `SpecifiedAttributes` type: this represents attributes which is actually specified in front-matter
2. Redefine `Attributes` type as `Required<SpecifiedAttributes>` (About `Required<T>` type, please refer to [TypeScript handbook](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredt))
3. Pass `SpecifiedAttributes` type to `fm`'s type argument: this changes the inferred type of `attributes` variable to `SpecifiedAttributes` from `any`

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)
