### PR TITLE
Refactor tokenizer

### DIFF
--- a/src/template/tokenize.ts
+++ b/src/template/tokenize.ts
@@ -31,17 +31,20 @@ const unopened = (input: string, token: Token<TokenType.CLOSE_TAG>) => {
 
 const parseNumeric = (value: string) => Number(value);
 
+const tokenizeUsingEsprima = (source: string, input: string, loc: Loc) => {
+  try {
+    return esprima.tokenize(input, { loc: true }) as EsprimaToken[];
+  } catch (e) {
+    unexpected(source, {
+      line: loc.line + e.lineNumber - 1,
+      column: loc.column + e.index - input.length,
+    });
+  }
+};
+
 const tokenizeInTag = (source: string, input: string, loc: Loc) => {
   const output = [];
-  let tokens: EsprimaToken[] = [];
-
-  try {
-    tokens = esprima.tokenize(input, { loc: true }) as any;
-  } catch (e) {
-    loc.line += e.lineNumber - 1;
-    loc.column += e.index - input.length;
-    unexpected(source, loc);
-  }
+  const tokens = tokenizeUsingEsprima(source, input, loc);
 
   const size = input.length;
   const length = tokens.length;

--- a/src/template/tokenize.ts
+++ b/src/template/tokenize.ts
@@ -144,8 +144,8 @@ export const tokenize = (input: string) => {
   const length = source.length;
 
   const loc: Loc = { line: 1, column: 1 };
-  let output: AnyToken[] = [];
-  let buffer: string[] = [];
+  const output: AnyToken[] = [];
+  const buffer: string[] = [];
   let bufLoc: Loc | null = null;
   let inTag = false;
   let pos = 0;
@@ -170,7 +170,7 @@ export const tokenize = (input: string) => {
           { ...loc, column: loc.column - 1 },
         ),
       );
-      buffer = [];
+      buffer.length = 0;
       bufLoc = null;
     }
   };
@@ -244,9 +244,9 @@ export const tokenize = (input: string) => {
           }
 
           inTag = false;
-          output = [...output, ...tokenizeInTag(input, buf2str(), loc), close];
+          output.push(...tokenizeInTag(input, buf2str(), loc), close);
           pos += 2;
-          buffer = [];
+          buffer.length = 0;
         } else {
           buffer.push(str);
         }
@@ -269,10 +269,10 @@ export const tokenize = (input: string) => {
           }
 
           inTag = false;
-          output = [...output, ...tokenizeInTag(input, buf2str(), loc), close];
+          output.push(...tokenizeInTag(input, buf2str(), loc), close);
           pos++;
           loc.column++;
-          buffer = [];
+          buffer.length = 0;
         } else {
           buffer.push(str);
         }

--- a/src/template/tokenize.ts
+++ b/src/template/tokenize.ts
@@ -31,7 +31,13 @@ const unopened = (input: string, token: Token<TokenType.CLOSE_TAG>) => {
 
 const parseNumeric = (value: string) => Number(value);
 
-const tokenizeUsingEsprima = (source: string, input: string, loc: Loc) => {
+interface TokenizationContext {
+  source: string;
+  input: string;
+  loc: Loc;
+}
+
+const tokenizeUsingEsprima = ({ source, input, loc }: TokenizationContext) => {
   try {
     return esprima.tokenize(input, { loc: true }) as EsprimaToken[];
   } catch (e) {
@@ -42,9 +48,9 @@ const tokenizeUsingEsprima = (source: string, input: string, loc: Loc) => {
   }
 };
 
-const tokenizeInTag = (source: string, input: string, loc: Loc) => {
+const tokenizeInTag = ({ source, input, loc }: TokenizationContext) => {
   const output = [];
-  const tokens = tokenizeUsingEsprima(source, input, loc);
+  const tokens = tokenizeUsingEsprima({ source, input, loc });
 
   const size = input.length;
   const length = tokens.length;
@@ -244,7 +250,7 @@ export const tokenize = (input: string) => {
           }
 
           inTag = false;
-          output.push(...tokenizeInTag(input, buf2str(), loc), close);
+          output.push(...tokenizeInTag({ source: input, input: buf2str(), loc }), close);
           pos += 2;
           buffer.length = 0;
         } else {
@@ -269,7 +275,7 @@ export const tokenize = (input: string) => {
           }
 
           inTag = false;
-          output.push(...tokenizeInTag(input, buf2str(), loc), close);
+          output.push(...tokenizeInTag({ source: input, input: buf2str(), loc }), close);
           pos++;
           loc.column++;
           buffer.length = 0;

--- a/src/template/tokenize.ts
+++ b/src/template/tokenize.ts
@@ -11,9 +11,9 @@ type EsprimaToken = {
   };
 };
 
-const unexpected = (input: string, loc: Loc) => {
+function unexpected(input: string, loc: Loc): never {
   throw new SyntaxError(ErrorType.UNEXPECTED, input, loc, loc);
-};
+}
 
 const unclosed = (input: string, tokens: AnyToken[]) => {
   const open = tokens.find((token) => token.type === TokenType.OPEN_TAG);


### PR DESCRIPTION
## What does this do / why do we need it?

This PR refactors tokenizer according to the following policies.

- Try to use `const` instead of `let` as much as possible
- Try to reduce human errors TypeScript compiler cannot detect
- Try to simplify state transitions

## How this PR fixes the problem?

1. Split up `tokenizeInTag` function into smaller functions
    - `tokenizeUsingEsprima` : newly defined function, which deals with Esprima API call and its errors
2. Replace `<array variable> = [];` with `<array variable>.length = 0;` and change related `let` statements into `const` statements
    - Modifying `length` property of array to `0` means to empty the array (About this behavior, please refer to [ECMAScript Specification (9.4.2 Array Exotic Objects)](https://www.ecma-international.org/ecma-262/9.0/#sec-array-exotic-objects))
3. Refactor functions so as not to mutate properties of their arguments as much as possible
4. Improve readability by using destructuring syntax and `interface`

<!-- ## What should your reviewer look out for in this PR? -->

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)
