### PR TITLE
chore: move @types/node to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "lib"
   ],
   "dependencies": {
-    "@types/node": "^13.11.1",
     "chalk": "^4.0.0",
     "change-case": "^4.1.1",
     "esprima": "^4.0.1",
@@ -67,6 +66,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "1.22.2",
+    "@types/node": "^13.11.1",
     "@types/esprima": "4.0.2",
     "@types/globby": "9.1.0",
     "@types/inquirer": "6.5.0",


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

moves `@types/node` to devDependencies

Reason: to reduce size of node_modules for the user.
I was looking through my node_modules, trying to reduce size, and I noticed that `@types/node` was included in the dependencies instead of devDependencies, which results in `@types/node` being included in the node_modules inside the installed package.



## How does this PR fixes the problem?

moved `@types/node` to devDependencies so that it will not be included when user installs the package.

## What should your reviewer look out for in this PR?

check that there are no type error for the users

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

## Additional Comments (if any)

n/a

## Which issue(s) does this PR fix?

n/a
<!--
fixes #
fixes #
-->
