### PR TITLE
Add custom tags

### DIFF
--- a/packages/@scaffdog/config/src/validator.test.ts
+++ b/packages/@scaffdog/config/src/validator.test.ts
@@ -8,6 +8,7 @@ test('valid - full', (t) => {
       foo: 'bar',
     },
     helpers: [() => 'str', () => {}],
+    tags: ['{{', '}}'] as const,
   };
 
   t.is(validateConfig(config), config);
@@ -29,9 +30,19 @@ test('invalid - empty', (t) => {
   });
 });
 
-test('invalid - types', (t) => {
+test('invalid - types - files', (t) => {
   const config = {
     files: null,
+  };
+
+  t.throws(() => {
+    validateConfig(config);
+  });
+});
+
+test('invalid - types - tags', (t) => {
+  const config = {
+    tags: [],
   };
 
   t.throws(() => {

--- a/packages/@scaffdog/config/src/validator.ts
+++ b/packages/@scaffdog/config/src/validator.ts
@@ -9,6 +9,7 @@ const configSchema = z.object({
   files: z.array(z.string()),
   variables: z.record(variableSchema).optional(),
   helpers: z.array(z.function()).optional(),
+  tags: z.tuple([z.string(), z.string()]).optional(),
 });
 
 export const validateConfig = (maybeConfig: unknown): Config => {

--- a/packages/@scaffdog/core/src/generate.test.ts
+++ b/packages/@scaffdog/core/src/generate.test.ts
@@ -3,11 +3,12 @@ import test from 'ava';
 import { generate } from './generate';
 
 const cwd = process.cwd();
+const root = path.join(cwd, 'path', 'to');
 
 test('basic', (t) => {
   const opts = {
     cwd,
-    root: path.join(cwd, 'path', 'to'),
+    root,
   };
 
   t.deepEqual(
@@ -38,7 +39,7 @@ output.dir: {{ output.dir }}
     ),
     [
       {
-        output: path.resolve(opts.root, 'plain.txt'),
+        output: path.resolve(root, 'plain.txt'),
         filename: 'plain.txt',
         content: `
 inputs.name: value
@@ -52,9 +53,37 @@ output.dir: path/to
 `.trim(),
       },
       {
-        output: path.resolve(opts.root, 'value.js'),
+        output: path.resolve(root, 'value.js'),
         filename: 'value.js',
         content: 'path/to/value.js',
+      },
+    ],
+  );
+});
+
+test('custom', (t) => {
+  const opts = {
+    cwd,
+    root,
+    tags: ['<%=', '=%>'] as const,
+  };
+
+  t.deepEqual(
+    generate(
+      [
+        {
+          filename: 'plain.txt',
+          content: `cwd: <%= cwd =%>`,
+        },
+      ],
+      new Map(),
+      opts,
+    ),
+    [
+      {
+        output: path.resolve(opts.root, 'plain.txt'),
+        filename: 'plain.txt',
+        content: `cwd: ${cwd}`,
       },
     ],
   );

--- a/packages/@scaffdog/core/src/generate.ts
+++ b/packages/@scaffdog/core/src/generate.ts
@@ -1,11 +1,18 @@
 import path from 'path';
 import { compile, createContext, extendContext } from '@scaffdog/engine';
-import type { File, HelperMap, Template, VariableMap } from '@scaffdog/types';
+import type {
+  File,
+  HelperMap,
+  TagPair,
+  Template,
+  VariableMap,
+} from '@scaffdog/types';
 
 export type GenerateOptions = {
   cwd: string;
   root: string;
   helpers: HelperMap;
+  tags?: TagPair;
 };
 
 export type GenerateResult = File[];
@@ -29,6 +36,7 @@ export const generate = (
       cwd: opts.cwd,
       helpers: opts.helpers,
       variables,
+      tags: opts.tags,
     });
 
     const name = compile(template.filename, context);

--- a/packages/@scaffdog/engine/README.md
+++ b/packages/@scaffdog/engine/README.md
@@ -12,6 +12,8 @@ $ npm install @scaffdog/engine
 
 ## Usage
 
+The following code is a basic example:
+
 ```typescript
 import { compile, createContext } from '@scaffdog/engine';
 
@@ -22,4 +24,18 @@ const context = createContext({
 
 const output = compile(`OUTPUT: {{ name | greet }}`, context);
 // --> "OUTPUT: Hi scaffdog!"
+```
+
+### Custom Tags
+
+You can change the tag delimiter with `context.tags`:
+
+```typescript
+import { compile, createContext } from '@scaffdog/engine';
+
+const context = createContext({
+  tags: ['<%=', '=%>'],
+});
+
+compile(`<%= "custom tag" =%>`, context);
 ```

--- a/packages/@scaffdog/engine/src/compile.test.ts
+++ b/packages/@scaffdog/engine/src/compile.test.ts
@@ -1,0 +1,37 @@
+import type { ExecutionContext } from 'ava';
+import test from 'ava';
+import type { Context } from '@scaffdog/types';
+import { createContext, extendContext } from './context';
+import { compile } from './compile';
+
+const context = createContext({
+  variables: new Map([['name', 'scaffdog']]),
+  helpers: new Map([['greet', (_, name: string) => `Hi ${name}!`]]),
+});
+
+const valid = (
+  t: ExecutionContext,
+  input: string,
+  context: Context,
+  expected: string,
+) => {
+  t.is(compile(input, context), expected);
+};
+
+test(
+  'basic',
+  valid,
+  'before {{ name | greet }} after',
+  context,
+  'before Hi scaffdog! after',
+);
+
+test(
+  'custom tag',
+  valid,
+  'before <%= name | greet =%> after',
+  extendContext(context, {
+    tags: ['<%=', '=%>'],
+  }),
+  'before Hi scaffdog! after',
+);

--- a/packages/@scaffdog/engine/src/compile.ts
+++ b/packages/@scaffdog/engine/src/compile.ts
@@ -4,7 +4,11 @@ import { Parser } from './parser';
 import { tokenize } from './tokenize';
 
 export const compile = (input: string, context: Context): string => {
-  const parser = new Parser(tokenize(input), input);
+  const tokens = tokenize(input, {
+    tags: context.tags,
+  });
+
+  const parser = new Parser(tokens, input);
   const compiler = new Compiler(context, input);
   const ast = parser.parse();
   const output = compiler.compile(ast);

--- a/packages/@scaffdog/engine/src/context.test.ts
+++ b/packages/@scaffdog/engine/src/context.test.ts
@@ -1,0 +1,67 @@
+import type { Context } from '@scaffdog/types';
+import test from 'ava';
+import { createContext, extendContext } from './context';
+import { helpers } from './helpers';
+
+test('createContext', (t) => {
+  const expected: Context = {
+    cwd: process.cwd(),
+    helpers,
+    variables: new Map(),
+    tags: ['{{', '}}'],
+  };
+
+  t.deepEqual(createContext({}), expected);
+
+  const extendHelpers = new Map([['test', () => '']]);
+
+  t.deepEqual(
+    createContext({
+      helpers: extendHelpers,
+    }),
+    {
+      ...expected,
+      helpers: new Map([...helpers, ...extendHelpers]),
+    },
+  );
+
+  t.deepEqual(
+    createContext({
+      cwd: undefined,
+      helpers: undefined,
+      variables: undefined,
+      tags: undefined,
+    }),
+    createContext({}),
+  );
+});
+
+test('extendContext', (t) => {
+  const helpers1 = new Map([['test1', () => '']]);
+  const helpers2 = new Map([['test2', () => '']]);
+
+  const variables1 = new Map([['var1', 'val1']]);
+  const variables2 = new Map([['var2', 'val2']]);
+
+  const context = createContext({
+    cwd: 'base',
+    helpers: helpers1,
+    variables: variables1,
+  });
+
+  t.deepEqual(extendContext(context, {}), context);
+
+  t.deepEqual(
+    extendContext(context, {
+      cwd: 'extend',
+      helpers: helpers2,
+      variables: variables2,
+    }),
+    {
+      ...context,
+      cwd: 'extend',
+      helpers: new Map([...helpers, ...helpers1, ...helpers2]),
+      variables: new Map([...variables1, ...variables2]),
+    },
+  );
+});

--- a/packages/@scaffdog/engine/src/context.ts
+++ b/packages/@scaffdog/engine/src/context.ts
@@ -1,39 +1,37 @@
 import type { Context } from '@scaffdog/types';
 import { helpers } from './helpers';
+import { defaults } from './syntax';
 
 const mergeMap = <T>(map1: Map<string, T>, map2: Map<string, T>) =>
   new Map([...map1, ...map2]);
-
-export const createContext = (partial: Partial<Context>): Context => {
-  const ctx = {
-    cwd: process.cwd(),
-    helpers,
-    variables: new Map(),
-    ...partial,
-  };
-
-  if (partial.helpers != null) {
-    ctx.helpers = mergeMap(helpers, partial.helpers);
-  }
-
-  return ctx;
-};
 
 export const extendContext = (
   context: Context,
   partial: Partial<Context>,
 ): Context => {
-  const ctx = {
-    ...context,
-  };
+  const ctx = { ...context };
+
+  ctx.cwd = partial.cwd ?? ctx.cwd;
+  ctx.tags = partial.tags ?? ctx.tags;
 
   if (partial.helpers != null) {
-    ctx.helpers = mergeMap(context.helpers, partial.helpers);
+    ctx.helpers = mergeMap(ctx.helpers, partial.helpers);
   }
 
   if (partial.variables != null) {
-    ctx.variables = mergeMap(context.variables, partial.variables);
+    ctx.variables = mergeMap(ctx.variables, partial.variables);
   }
 
   return ctx;
 };
+
+export const createContext = (partial: Partial<Context>): Context =>
+  extendContext(
+    {
+      cwd: process.cwd(),
+      helpers,
+      variables: new Map(),
+      tags: defaults.tags,
+    },
+    partial,
+  );

--- a/packages/@scaffdog/engine/src/syntax.ts
+++ b/packages/@scaffdog/engine/src/syntax.ts
@@ -1,0 +1,5 @@
+import type { TagPair } from '@scaffdog/types';
+
+export const defaults = Object.freeze({
+  tags: ['{{', '}}'] as TagPair,
+});

--- a/packages/@scaffdog/engine/src/tokenize.test.ts
+++ b/packages/@scaffdog/engine/src/tokenize.test.ts
@@ -1,80 +1,84 @@
 import type { ExecutionContext } from 'ava';
 import test from 'ava';
+import type { TokenizeOptions } from './tokenize';
 import { tokenize } from './tokenize';
 import type { AnyToken } from './tokens';
 import { createToken } from './tokens';
 
-const valid = (
+const valid = (options: Partial<TokenizeOptions> = {}) => (
   t: ExecutionContext,
   input: string,
   expected: (AnyToken | null)[],
 ) => {
-  t.deepEqual(expected, tokenize(input));
+  t.deepEqual(expected, tokenize(input, options));
 };
 
-const invalid = (t: ExecutionContext, input: string) => {
+const invalid = (options: Partial<TokenizeOptions> = {}) => (
+  t: ExecutionContext,
+  input: string,
+) => {
   t.throws(() => {
-    tokenize(input);
+    tokenize(input, options);
   });
 };
 
-test('raw - true', valid, 'true', [
+test('raw - true', valid(), 'true', [
   createToken('STRING', 'true', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 4 },
   }),
 ]);
 
-test('raw - false', valid, 'false', [
+test('raw - false', valid(), 'false', [
   createToken('STRING', 'false', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 5 },
   }),
 ]);
 
-test('raw - null', valid, 'null', [
+test('raw - null', valid(), 'null', [
   createToken('STRING', 'null', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 4 },
   }),
 ]);
 
-test('raw - undefined', valid, 'undefined', [
+test('raw - undefined', valid(), 'undefined', [
   createToken('STRING', 'undefined', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 9 },
   }),
 ]);
 
-test('raw - string', valid, 'foo', [
+test('raw - string', valid(), 'foo', [
   createToken('STRING', 'foo', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
   }),
 ]);
 
-test('raw - numeric', valid, '123', [
+test('raw - numeric', valid(), '123', [
   createToken('STRING', '123', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
   }),
 ]);
 
-test('raw - incomplete open tag', valid, '{ {', [
+test('raw - incomplete open tag', valid(), '{ {', [
   createToken('STRING', '{ {', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
   }),
 ]);
 
-test('raw - incomplete close tag', valid, '} }', [
+test('raw - incomplete close tag', valid(), '} }', [
   createToken('STRING', '} }', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
   }),
 ]);
 
-test('tag - empty', valid, '{{}}', [
+test('tag - empty', valid(), '{{}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -85,7 +89,7 @@ test('tag - empty', valid, '{{}}', [
   }),
 ]);
 
-test('tag - trimed open', valid, '{{-  }}', [
+test('tag - trimed open', valid(), '{{-  }}', [
   createToken('OPEN_TAG', '{{-', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
@@ -96,7 +100,7 @@ test('tag - trimed open', valid, '{{-  }}', [
   }),
 ]);
 
-test('tag - trimed close', valid, '{{ -}}', [
+test('tag - trimed close', valid(), '{{ -}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -107,7 +111,7 @@ test('tag - trimed close', valid, '{{ -}}', [
   }),
 ]);
 
-test('tag - trimed', valid, '{{- -}}', [
+test('tag - trimed', valid(), '{{- -}}', [
   createToken('OPEN_TAG', '{{-', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 3 },
@@ -118,7 +122,7 @@ test('tag - trimed', valid, '{{- -}}', [
   }),
 ]);
 
-test('tag - identifier', valid, '{{ identifier }}', [
+test('tag - identifier', valid(), '{{ identifier }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -135,7 +139,7 @@ test('tag - identifier', valid, '{{ identifier }}', [
 
 test(
   'tag - identifier and dot notation (string)',
-  valid,
+  valid(),
   '{{ identifier.prop }}',
   [
     createToken('OPEN_TAG', '{{', {
@@ -163,13 +167,13 @@ test(
 
 test(
   'tag - identifier and dot notation (number)',
-  invalid,
+  invalid(),
   '{{ identifier.0 }}',
 );
 
 test(
   'tag - identifier and bracket accessor (string)',
-  valid,
+  valid(),
   `{{ identifier["prop"] }}{{ident['prop']}}`,
   [
     createToken('OPEN_TAG', '{{', {
@@ -223,7 +227,7 @@ test(
   ],
 );
 
-test('tag - comment out', valid, '{{/*a comment*/ }}', [
+test('tag - comment out', valid(), '{{/*a comment*/ }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -234,7 +238,7 @@ test('tag - comment out', valid, '{{/*a comment*/ }}', [
   }),
 ]);
 
-test('tag - pipe', valid, '{{ foo|   bar }}', [
+test('tag - pipe', valid(), '{{ foo|   bar }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -257,7 +261,7 @@ test('tag - pipe', valid, '{{ foo|   bar }}', [
   }),
 ]);
 
-test('tag - true', valid, '{{true}}', [
+test('tag - true', valid(), '{{true}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -272,7 +276,7 @@ test('tag - true', valid, '{{true}}', [
   }),
 ]);
 
-test('tag - false', valid, '{{  false}}', [
+test('tag - false', valid(), '{{  false}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -287,7 +291,7 @@ test('tag - false', valid, '{{  false}}', [
   }),
 ]);
 
-test('tag - null', valid, '{{ null }}', [
+test('tag - null', valid(), '{{ null }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -302,7 +306,7 @@ test('tag - null', valid, '{{ null }}', [
   }),
 ]);
 
-test('tag - undefined', valid, '{{undefined }}', [
+test('tag - undefined', valid(), '{{undefined }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -317,7 +321,7 @@ test('tag - undefined', valid, '{{undefined }}', [
   }),
 ]);
 
-test('tag - string (single quote)', valid, "{{ 'string'}}", [
+test('tag - string (single quote)', valid(), "{{ 'string'}}", [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -332,7 +336,7 @@ test('tag - string (single quote)', valid, "{{ 'string'}}", [
   }),
 ]);
 
-test('tag - string (double quote)', valid, '{{ "string"}}', [
+test('tag - string (double quote)', valid(), '{{ "string"}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -347,7 +351,7 @@ test('tag - string (double quote)', valid, '{{ "string"}}', [
   }),
 ]);
 
-test('tag - number (natural)', valid, '{{ 123 }}', [
+test('tag - number (natural)', valid(), '{{ 123 }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -362,7 +366,7 @@ test('tag - number (natural)', valid, '{{ 123 }}', [
   }),
 ]);
 
-test('tag - number (float)', valid, '{{ 123.456}}', [
+test('tag - number (float)', valid(), '{{ 123.456}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -377,7 +381,7 @@ test('tag - number (float)', valid, '{{ 123.456}}', [
   }),
 ]);
 
-test('tag - number (positive)', valid, '{{ +123 }}', [
+test('tag - number (positive)', valid(), '{{ +123 }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -392,7 +396,7 @@ test('tag - number (positive)', valid, '{{ +123 }}', [
   }),
 ]);
 
-test('tag - number (negative)', valid, '{{ -123 }}', [
+test('tag - number (negative)', valid(), '{{ -123 }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -407,7 +411,7 @@ test('tag - number (negative)', valid, '{{ -123 }}', [
   }),
 ]);
 
-test('tag - number (negative float)', valid, '{{ -0.12}}', [
+test('tag - number (negative float)', valid(), '{{ -0.12}}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -422,7 +426,7 @@ test('tag - number (negative float)', valid, '{{ -0.12}}', [
   }),
 ]);
 
-test('tag - number (hex)', valid, '{{ 0xF }}', [
+test('tag - number (hex)', valid(), '{{ 0xF }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -437,12 +441,106 @@ test('tag - number (hex)', valid, '{{ 0xF }}', [
   }),
 ]);
 
-test('tag - unclosing', invalid, '{{ foo "bar"');
-test('tag - unopening', invalid, 'foo bar }}');
-test('tag - duplicate opening 1', invalid, '{{ {{');
-test('tag - duplicate opening 2', invalid, '{{ {{ }}');
+test(
+  'tag - custom empty',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%==%>',
+  [
+    createToken('OPEN_TAG', '<%=', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 3 },
+    }),
+    createToken('CLOSE_TAG', '=%>', {
+      start: { line: 1, column: 4 },
+      end: { line: 1, column: 6 },
+    }),
+  ],
+);
 
-test('complex', valid, '{{ foo | bar "hoge" | 123 | null }}', [
+test(
+  'tag - custom string',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%= "{{}}" =%>',
+  [
+    createToken('OPEN_TAG', '<%=', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 3 },
+    }),
+    createToken('STRING', '{{}}', {
+      start: { line: 1, column: 5 },
+      end: { line: 1, column: 10 },
+    }),
+    createToken('CLOSE_TAG', '=%>', {
+      start: { line: 1, column: 12 },
+      end: { line: 1, column: 14 },
+    }),
+  ],
+);
+
+test(
+  'tag - custom trimed open',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%=-  =%>',
+  [
+    createToken('OPEN_TAG', '<%=-', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 4 },
+    }),
+    createToken('CLOSE_TAG', '=%>', {
+      start: { line: 1, column: 7 },
+      end: { line: 1, column: 9 },
+    }),
+  ],
+);
+
+test(
+  'tag - custom trimed close',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%= -=%>',
+  [
+    createToken('OPEN_TAG', '<%=', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 3 },
+    }),
+    createToken('CLOSE_TAG', '-=%>', {
+      start: { line: 1, column: 5 },
+      end: { line: 1, column: 8 },
+    }),
+  ],
+);
+
+test(
+  'tag - custom trimed',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%=- -=%>',
+  [
+    createToken('OPEN_TAG', '<%=-', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 4 },
+    }),
+    createToken('CLOSE_TAG', '-=%>', {
+      start: { line: 1, column: 6 },
+      end: { line: 1, column: 9 },
+    }),
+  ],
+);
+
+test('tag - unclosing', invalid(), '{{ foo "bar"');
+test('tag - unopening', invalid(), 'foo bar }}');
+test('tag - duplicate opening 1', invalid(), '{{ {{');
+test('tag - duplicate opening 2', invalid(), '{{ {{ }}');
+
+test('complex', valid(), '{{ foo | bar "hoge" | 123 | null }}', [
   createToken('OPEN_TAG', '{{', {
     start: { line: 1, column: 1 },
     end: { line: 1, column: 2 },
@@ -484,3 +582,53 @@ test('complex', valid, '{{ foo | bar "hoge" | 123 | null }}', [
     end: { line: 1, column: 35 },
   }),
 ]);
+
+test(
+  'complex - custom',
+  valid({
+    tags: ['<%=', '=%>'],
+  }),
+  '<%= foo | bar "hoge" | 123 | null =%>',
+  [
+    createToken('OPEN_TAG', '<%=', {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: 3 },
+    }),
+    createToken('IDENT', 'foo', {
+      start: { line: 1, column: 5 },
+      end: { line: 1, column: 7 },
+    }),
+    createToken('PIPE', '|', {
+      start: { line: 1, column: 9 },
+      end: { line: 1, column: 9 },
+    }),
+    createToken('IDENT', 'bar', {
+      start: { line: 1, column: 11 },
+      end: { line: 1, column: 13 },
+    }),
+    createToken('STRING', 'hoge', {
+      start: { line: 1, column: 15 },
+      end: { line: 1, column: 20 },
+    }),
+    createToken('PIPE', '|', {
+      start: { line: 1, column: 22 },
+      end: { line: 1, column: 22 },
+    }),
+    createToken('NUMBER', 123, {
+      start: { line: 1, column: 24 },
+      end: { line: 1, column: 26 },
+    }),
+    createToken('PIPE', '|', {
+      start: { line: 1, column: 28 },
+      end: { line: 1, column: 28 },
+    }),
+    createToken('NULL', null, {
+      start: { line: 1, column: 30 },
+      end: { line: 1, column: 33 },
+    }),
+    createToken('CLOSE_TAG', '=%>', {
+      start: { line: 1, column: 35 },
+      end: { line: 1, column: 37 },
+    }),
+  ],
+);

--- a/packages/@scaffdog/engine/src/tokens.ts
+++ b/packages/@scaffdog/engine/src/tokens.ts
@@ -1,21 +1,5 @@
 import type { SourceLocation } from '@scaffdog/types';
 
-export type TokenType =
-  | 'ILLEGAL'
-  | 'EOF'
-  | 'NULL'
-  | 'UNDEFINED'
-  | 'BOOLEAN'
-  | 'STRING'
-  | 'NUMBER'
-  | 'IDENT'
-  | 'DOT'
-  | 'OPEN_BRACKET'
-  | 'CLOSE_BRACKET'
-  | 'PIPE'
-  | 'OPEN_TAG'
-  | 'CLOSE_TAG';
-
 export type TokenMap = {
   ILLEGAL: null;
   EOF: null;
@@ -33,27 +17,17 @@ export type TokenMap = {
   CLOSE_TAG: string;
 };
 
+export type TokenType = keyof TokenMap;
+
 export type Token<T extends TokenType> = {
   type: T;
   literal: TokenMap[T];
   loc: SourceLocation;
 };
 
-export type AnyToken =
-  | Token<'ILLEGAL'>
-  | Token<'EOF'>
-  | Token<'NULL'>
-  | Token<'UNDEFINED'>
-  | Token<'BOOLEAN'>
-  | Token<'STRING'>
-  | Token<'NUMBER'>
-  | Token<'IDENT'>
-  | Token<'DOT'>
-  | Token<'OPEN_BRACKET'>
-  | Token<'CLOSE_BRACKET'>
-  | Token<'PIPE'>
-  | Token<'OPEN_TAG'>
-  | Token<'CLOSE_TAG'>;
+export type AnyToken = {
+  [P in TokenType]: Token<P>;
+}[TokenType];
 
 export const createToken = <T extends TokenType>(
   type: T,

--- a/packages/@scaffdog/types/src/config.ts
+++ b/packages/@scaffdog/types/src/config.ts
@@ -1,11 +1,13 @@
 import type { Merge } from 'type-fest';
 import type { HelperMap, HelperRecord, HelperRegister } from './helper';
+import type { TagPair } from './tag';
 import type { VariableMap, VariableRecord } from './variable';
 
 export type Config = {
   files: string[];
   variables?: VariableRecord;
   helpers?: (HelperRecord | HelperRegister)[];
+  tags?: TagPair;
 };
 
 export type ResolvedConfig = Merge<

--- a/packages/@scaffdog/types/src/context.ts
+++ b/packages/@scaffdog/types/src/context.ts
@@ -1,8 +1,10 @@
 import type { HelperMap } from './helper';
+import type { TagPair } from './tag';
 import type { VariableMap } from './variable';
 
 export type Context = {
   cwd: string;
   variables: VariableMap;
   helpers: HelperMap;
+  tags: TagPair;
 };

--- a/packages/@scaffdog/types/src/index.ts
+++ b/packages/@scaffdog/types/src/index.ts
@@ -3,5 +3,6 @@ export * from './context';
 export * from './file';
 export * from './helper';
 export * from './source';
+export * from './tag';
 export * from './template';
 export * from './variable';

--- a/packages/@scaffdog/types/src/tag.ts
+++ b/packages/@scaffdog/types/src/tag.ts
@@ -1,0 +1,1 @@
+export type TagPair = Readonly<[open: string, close: string]>;

--- a/packages/scaffdog/README.md
+++ b/packages/scaffdog/README.md
@@ -203,11 +203,32 @@ type Helper = (context: Context, ...args: any[]) => string;
 
 type HelperMap = Map<string, Helper>;
 
+type TagPair = Readonly<[open: string, close: string]>;
+
 type Context = {
   cwd: string;
   variables: VariableMap;
   helpers: HelperMap;
+  tags: TagPair;
 };
+```
+
+### Custom Tags
+
+The default tag delimiter available in templates is `{{` and `}}`.  
+You can change it with `tags`.
+
+```javascript
+module.exports = {
+  files: ['./*'],
+  tags: ['<%', '%>'],
+};
+```
+
+By setting the above config, `<%` and `%>` will be the tag delimiters in the template.
+
+```
+<% inputs.name %>
 ```
 
 ## Commands

--- a/packages/scaffdog/src/cmds/generate.ts
+++ b/packages/scaffdog/src/cmds/generate.ts
@@ -176,6 +176,7 @@ export default createCommand({
       cwd,
       variables: config.variables,
       helpers: new Map([...config.helpers, ...helpers]),
+      tags: config.tags,
     });
 
     for (const [key, value] of doc.variables) {
@@ -186,6 +187,7 @@ export default createCommand({
       cwd,
       root: dist,
       helpers: context.helpers,
+      tags: context.tags,
     });
   } catch (e) {
     if (e instanceof ScaffdogError) {


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

There are cases where we want to change the tag delimiter. For example, when outputting a file for the template engine.  
Allows you to change the tag delimiter from the configuration file to accommodate those cases.

```javascript
module.exports = {
  files: ['./*'],
  tags: ['<%', '%>'],
};
```

By setting the above config, `<%` and `%>` will be the tag delimiters in the template.

```
<% inputs.name %>
```

## How does PR fix the problem?

- n/a

## What should your reviewer look out for in this PR?

- n/a

## References

- n/a
