### PR TITLE
Add `before` / `after` helper functions

### DIFF
--- a/packages/@scaffdog/engine/src/helpers.test.ts
+++ b/packages/@scaffdog/engine/src/helpers.test.ts
@@ -2,9 +2,23 @@ import type { Context } from '@scaffdog/types';
 import type { ExecutionContext } from 'ava';
 import test from 'ava';
 import { compile } from './compile';
-import { createContext, extendContext } from './context';
+import { createContext } from './context';
 
-const context = createContext({});
+const context = createContext({
+  variables: new Map([
+    ['count5', '5'],
+    [
+      'multiline',
+      `
+line1
+line2
+line3
+line4
+line5
+    `.trim(),
+    ],
+  ]),
+});
 
 const equals = (
   t: ExecutionContext,
@@ -55,26 +69,62 @@ test('ltrim', equals, context, `{{ "  foo " | ltrim }}`, `foo `);
 
 test('rtrim', equals, context, `{{ "  foo " | rtrim }}`, `  foo`);
 
+test(
+  'before - number',
+  equals,
+  context,
+  `{{ multiline | before 3 }}`,
+  `line1\nline2`,
+);
+
+test(
+  'before - number (offset)',
+  equals,
+  context,
+  `{{ multiline | before 5 -1 }}`,
+  `line1\nline2\nline3`,
+);
+
+test(
+  'before - string',
+  equals,
+  context,
+  `{{ multiline | before "line4" }}`,
+  `line1\nline2\nline3`,
+);
+
+test(
+  'before - string (offset)',
+  equals,
+  context,
+  `{{ multiline | before "line2" 2 }}`,
+  `line1\nline2\nline3`,
+);
+
+test(
+  'before - string (no match)',
+  equals,
+  context,
+  `{{ multiline | before "NOT_FOUND" }}`,
+  `line1\nline2\nline3\nline4\nline5`,
+);
+
 /**
  * language
  */
 test(
   'eval - basic',
   equals,
-  extendContext(context, {
-    variables: new Map([['count', '5']]),
-  }),
-  `{{ eval "parseInt(count, 10) > 4 ? 'true' : 'false'" }}`,
+  context,
+  `{{ eval "parseInt(count5, 10) > 4 ? 'true' : 'false'" }}`,
   `true`,
 );
 
 test(
   'eval - chain',
   equals,
-  extendContext(context, {
-    variables: new Map([['count', '5']]),
-  }),
-  `{{ "foo" | eval "parseInt(count, 10) + 5" }}`,
+  context,
+  `{{ "foo" | eval "parseInt(count5, 10) + 5" }}`,
   `10`,
 );
 

--- a/packages/@scaffdog/engine/src/helpers.test.ts
+++ b/packages/@scaffdog/engine/src/helpers.test.ts
@@ -109,6 +109,46 @@ test(
   `line1\nline2\nline3\nline4\nline5`,
 );
 
+test(
+  'after - number',
+  equals,
+  context,
+  `{{ multiline | after 2 }}`,
+  `line3\nline4\nline5`,
+);
+
+test(
+  'after - number (offset)',
+  equals,
+  context,
+  `{{ multiline | after 4 -1 }}`,
+  `line4\nline5`,
+);
+
+test(
+  'after - string',
+  equals,
+  context,
+  `{{ multiline | after "line4" }}`,
+  `line5`,
+);
+
+test(
+  'after - string (offset)',
+  equals,
+  context,
+  `{{ multiline | after "line2" 1 }}`,
+  `line4\nline5`,
+);
+
+test(
+  'after - string (no match)',
+  equals,
+  context,
+  `{{ multiline | after "NOT_FOUND" }}`,
+  `line1\nline2\nline3\nline4\nline5`,
+);
+
 /**
  * language
  */

--- a/packages/@scaffdog/engine/src/helpers.ts
+++ b/packages/@scaffdog/engine/src/helpers.ts
@@ -60,6 +60,26 @@ helpers.set(
   },
 );
 
+helpers.set(
+  'after',
+  (_: Context, v: string, n: string | number, offset?: number) => {
+    const lines = splitLines(v);
+    const off = offset ?? 0;
+
+    if (typeof n === 'string') {
+      const regexp = new RegExp(n);
+      for (let i = 0; i < lines.length; i++) {
+        if (regexp.test(lines[i])) {
+          return lines.slice(i + 1 + off).join('\n');
+        }
+      }
+      return v;
+    }
+
+    return lines.slice(n + off).join('\n');
+  },
+);
+
 /**
  * date
  */

--- a/packages/@scaffdog/engine/src/helpers.ts
+++ b/packages/@scaffdog/engine/src/helpers.ts
@@ -7,6 +7,11 @@ import type { Context, HelperMap } from '@scaffdog/types';
 export const helpers: HelperMap = new Map();
 
 /**
+ * internal
+ */
+const splitLines = (v: string) => v.split(/\r?\n/);
+
+/**
  * string utils
  */
 helpers.set('camel', (_: Context, v: string) => cc.camelCase(v));
@@ -34,6 +39,26 @@ helpers.set('trim', (_: Context, v: string) => v.trim());
 helpers.set('ltrim', (_: Context, v: string) => v.trimStart());
 
 helpers.set('rtrim', (_: Context, v: string) => v.trimEnd());
+
+helpers.set(
+  'before',
+  (_: Context, v: string, n: string | number, offset?: number) => {
+    const lines = splitLines(v);
+    const off = offset ?? 0;
+
+    if (typeof n === 'string') {
+      const regexp = new RegExp(n);
+      for (let i = 0; i < lines.length; i++) {
+        if (regexp.test(lines[i])) {
+          return lines.slice(0, i + off).join('\n');
+        }
+      }
+      return v;
+    }
+
+    return lines.slice(0, n - 1 + off).join('\n');
+  },
+);
 
 /**
  * date

--- a/packages/scaffdog/README.md
+++ b/packages/scaffdog/README.md
@@ -502,6 +502,7 @@ When invoked on a pipe, the previous processing result is passed to the first ar
 | `ltrim`    | `[value: string]`                                       | Alias for `String.prototype.trimStart`.                                                                                                   |
 | `rtrim`    | `[value: string]`                                       | Alias for `String.prototype.trimEnd`.                                                                                                     |
 | `before`   | `[value: string, n: string \| number, offset?: number]` | Returns string before the position by `n`. If `n` is a number, it is the specified line; if it is a string, it is the first matched line. |
+| `after`    | `[value: string, n: string \| number, offset?: number]` | Returns string after the position by `n`. If `n` is a number, it is the specified line; if it is a string, it is the first matched line.  |
 | `eval`     | `[code: string]`                                        | Executes the specified code and returns the result.                                                                                       |
 | `date`     | `[format?: string]`                                     | See the [dayjs](https://day.js.org/docs/en/display/format) documentation for format details.                                              |
 | `noop`     | `[]`                                                    | Returns an empty string.                                                                                                                  |

--- a/packages/scaffdog/README.md
+++ b/packages/scaffdog/README.md
@@ -488,25 +488,26 @@ List of variables available in the template. You need to be aware that the file 
 
 When invoked on a pipe, the previous processing result is passed to the first argument.
 
-| name       | arguments                                               | description                                                                                                         |
-| :--------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------ |
-| `camel`    | `[value: string]`                                       | Conversion to a camel case.                                                                                         |
-| `snake`    | `[value: string]`                                       | Conversion to a snake case.                                                                                         |
-| `pascal`   | `[value: string]`                                       | Conversion to a pascal case.                                                                                        |
-| `kebab`    | `[value: string]`                                       | Conversion to a kebab case.                                                                                         |
-| `constant` | `[value: string]`                                       | Conversion to a constant case.                                                                                      |
-| `upper`    | `[value: string]`                                       | Conversion to a upper case.                                                                                         |
-| `lower`    | `[value: string]`                                       | Conversion to a lower case.                                                                                         |
-| `replace`  | `[value: string, pattern: string, replacement: string]` | Replace `pattern` with`replacement`. `pattern` is specified as a string, but it is treated as a regular expression. |
-| `trim`     | `[value: string]`                                       | Alias for `String.prototype.trim`.                                                                                  |
-| `ltrim`    | `[value: string]`                                       | Alias for `String.prototype.trimStart`.                                                                             |
-| `rtrim`    | `[value: string]`                                       | Alias for `String.prototype.trimEnd`.                                                                               |
-| `eval`     | `[code: string]`                                        | Executes the specified code and returns the result.                                                                 |
-| `date`     | `[format?: string]`                                     | See the [dayjs](https://day.js.org/docs/en/display/format) documentation for format details.                        |
-| `noop`     | `[]`                                                    | Returns an empty string.                                                                                            |
-| `define`   | `[value: string, key: string]`                          | Defines a local variable in the template scope.                                                                     |
-| `relative` | `[path: string]`                                        | Convert the path from the template file to the path from the destination file.                                      |
-| `read`     | `[path: string]`                                        | Read the specified file. The contents of the loaded file are also expanded as a template.                           |
+| name       | arguments                                               | description                                                                                                                               |
+| :--------- | :------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| `camel`    | `[value: string]`                                       | Conversion to a camel case.                                                                                                               |
+| `snake`    | `[value: string]`                                       | Conversion to a snake case.                                                                                                               |
+| `pascal`   | `[value: string]`                                       | Conversion to a pascal case.                                                                                                              |
+| `kebab`    | `[value: string]`                                       | Conversion to a kebab case.                                                                                                               |
+| `constant` | `[value: string]`                                       | Conversion to a constant case.                                                                                                            |
+| `upper`    | `[value: string]`                                       | Conversion to a upper case.                                                                                                               |
+| `lower`    | `[value: string]`                                       | Conversion to a lower case.                                                                                                               |
+| `replace`  | `[value: string, pattern: string, replacement: string]` | Replace `pattern` with `replacement`. `pattern` is specified as a string, but it is treated as a regular expression.                      |
+| `trim`     | `[value: string]`                                       | Alias for `String.prototype.trim`.                                                                                                        |
+| `ltrim`    | `[value: string]`                                       | Alias for `String.prototype.trimStart`.                                                                                                   |
+| `rtrim`    | `[value: string]`                                       | Alias for `String.prototype.trimEnd`.                                                                                                     |
+| `before`   | `[value: string, n: string \| number, offset?: number]` | Returns string before the position by `n`. If `n` is a number, it is the specified line; if it is a string, it is the first matched line. |
+| `eval`     | `[code: string]`                                        | Executes the specified code and returns the result.                                                                                       |
+| `date`     | `[format?: string]`                                     | See the [dayjs](https://day.js.org/docs/en/display/format) documentation for format details.                                              |
+| `noop`     | `[]`                                                    | Returns an empty string.                                                                                                                  |
+| `define`   | `[value: string, key: string]`                          | Defines a local variable in the template scope.                                                                                           |
+| `relative` | `[path: string]`                                        | Convert the path from the template file to the path from the destination file.                                                            |
+| `read`     | `[path: string]`                                        | Read the specified file. The contents of the loaded file are also expanded as a template.                                                 |
 
 ## Integration
 


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

When we generate code, we sometimes want to inject it into existing code.

- prepend
- append
- at (line / position)
- before
- after

So, We added the helper function required to realize the injection of the code.

## How does PR fix the problem?

n/a

## What should your reviewer look out for in this PR?

n/a

## References

- n/a
