### PR TITLE
fix(config): fix config schema on loader

### DIFF
--- a/packages/@scaffdog/config/src/validator.ts
+++ b/packages/@scaffdog/config/src/validator.ts
@@ -8,7 +8,9 @@ const variableSchema: z.ZodSchema<Variable> = z.lazy(() =>
 const configSchema = z.object({
   files: z.array(z.string()),
   variables: z.record(variableSchema).optional(),
-  helpers: z.array(z.function()).optional(),
+  helpers: z
+    .array(z.union([z.function(), z.record(z.string(), z.any())]))
+    .optional(),
   tags: z.tuple([z.string(), z.string()]).optional(),
 });
 


### PR DESCRIPTION
## What does this do / why do we need it?

Fixed a bug where the `helpers` field in the configuration file differed from the defined type.

```javascript
module.exports = {
  files: ['./*'],
  helpers: [
    {
      key: () => '',
    },
  ],
};
```

## What should your reviewer look out for in this PR?

n/a

## References

n/a
